### PR TITLE
Separate shared searchplugins from en-US

### DIFF
--- a/p12n_extract/p12n_extract.py
+++ b/p12n_extract/p12n_extract.py
@@ -37,7 +37,7 @@ class ProductizationData():
         self.data = nested_dict()
         self.errors = nested_dict()
         self.hashes = nested_dict()
-        self.enUS_searchplugins = {}
+        self.shared_searchplugins = {}
 
         # Initialize images with a default one
         self.images_list = [
@@ -53,18 +53,18 @@ class ProductizationData():
             'ElFTkSuQmCC'
         ]
 
-    def extract_splist_enUS(self, centralized_source, path, product, channel):
-        '''Store in enUS_searchplugins a list of en-US searchplugins (*.xml) in paths.'''
+    def extract_shared_splist(self, centralized_source, path, product, channel):
+        '''Store in share_searchplugins a list of searchplugins in /en-US (*.xml) in paths.'''
 
         try:
-            if product not in self.enUS_searchplugins:
-                self.enUS_searchplugins[product] = {}
-            if channel not in self.enUS_searchplugins[product]:
-                self.enUS_searchplugins[product][channel] = []
+            if product not in self.shared_searchplugins:
+                self.shared_searchplugins[product] = {}
+            if channel not in self.shared_searchplugins[product]:
+                self.shared_searchplugins[product][channel] = []
             for searchplugin in glob.glob(os.path.join(path, '*.xml')):
                 searchplugin_noext = os.path.splitext(
                     os.path.basename(searchplugin))[0]
-                self.enUS_searchplugins[product][
+                self.shared_searchplugins[product][
                     channel].append(searchplugin_noext)
         except:
             print 'Error: problem reading list of en-US searchplugins from {0}'.format(pathsource)
@@ -112,7 +112,7 @@ class ProductizationData():
                 # en-US is different from all other locales: I must analyze all
                 # XML files in the folder, since some searchplugins are not used
                 # in en-US but by other locales
-                list_sp = self.enUS_searchplugins[product][channel]
+                list_sp = self.shared_searchplugins[product][channel]
 
             if locale != 'en-US':
                 # Get a list of all files inside search_path
@@ -120,7 +120,7 @@ class ProductizationData():
                     filename = os.path.basename(searchplugin)
                     # Remove extension
                     filename_noext = os.path.splitext(filename)[0]
-                    if filename_noext in self.enUS_searchplugins[product][channel]:
+                    if filename_noext in self.shared_searchplugins[product][channel]:
                         # File exists but has the same name of an en-US
                         # searchplugin.
                         errors.append(
@@ -138,7 +138,7 @@ class ProductizationData():
                 sp_file = os.path.join(search_path, sp + '.xml')
                 existing_file = os.path.isfile(sp_file)
 
-                if sp in self.enUS_searchplugins[product][channel] and existing_file and locale != 'en-US':
+                if sp in self.shared_searchplugins[product][channel] and existing_file and locale != 'en-US':
                     # There's a problem: file exists but has the same name of an
                     # en-US searchplugin. This file will never be picked at build
                     # time, so let's analyze en-US and use it for JSON, acting
@@ -571,7 +571,7 @@ class ProductizationData():
                         path_centralized = os.path.join(
                             channel_data['source_path'], repo_folder, 'mail', 'locales', 'search', 'list.json')
 
-                    self.extract_splist_enUS(
+                    self.extract_shared_splist(
                         path_centralized, path_enUS, product,
                         requested_channel)
                     self.extract_searchplugins_product(

--- a/p12n_extract/p12n_extract.py
+++ b/p12n_extract/p12n_extract.py
@@ -633,7 +633,8 @@ class ProductizationData():
         self.data['images'] = images_data
 
         # Remove the extra locale 'shared' from data before saving
-        del(self.data['locales']['shared'])
+        if 'shared' in self.data['locales']:
+            del(self.data['locales']['shared'])
 
         # Save data on file
         metadata = {

--- a/p12n_extract/p12n_extract.py
+++ b/p12n_extract/p12n_extract.py
@@ -575,7 +575,8 @@ class ProductizationData():
                         path_centralized, path_enUS, product,
                         requested_channel)
 
-                    # Extract all shared searchplugins in a special 'shared' locale
+                    # Extract all shared searchplugins in a special 'shared'
+                    # locale
                     self.extract_searchplugins_product(
                         path_centralized, path_enUS, product, 'shared',
                         requested_channel)

--- a/p12n_extract/p12n_extract.py
+++ b/p12n_extract/p12n_extract.py
@@ -54,7 +54,7 @@ class ProductizationData():
         ]
 
     def extract_shared_splist(self, centralized_source, path, product, channel):
-        '''Store in share_searchplugins a list of searchplugins in /en-US (*.xml) in paths.'''
+        '''Store in shared_searchplugins a list of searchplugins in /en-US (*.xml)'''
 
         try:
             if product not in self.shared_searchplugins:
@@ -109,7 +109,7 @@ class ProductizationData():
                     errors.append('there are duplicated items ({0}) in the list'.format(
                         duplicated_items_str))
             else:
-                # For 'shared' I must analyze all XML files in the en-US folder,
+                # For 'shared' I must analyze all XML files in the folder,
                 # since some searchplugins are not used in en-US but by other
                 # locales
                 list_sp = self.shared_searchplugins[product][channel]
@@ -283,8 +283,9 @@ class ProductizationData():
                         errors.append(
                             'error analyzing searchplugin {0} <code>{1}</code>'.format(searchplugin_info, str(e)))
                 else:
-                    # File does not exist, locale is using the same plugin available in /en-US,
-                    # I have to retrieve it from the existing dictionary
+                    # File does not exist, locale is using the same plugin
+                    # available in the shared folder. I have to retrieve it
+                    # from the existing dictionary
                     if sp in self.data['locales']['shared'][product][channel]['searchplugins']:
                         searchplugin_shared = self.data['locales'][
                             'shared'][product][channel]['searchplugins'][sp]

--- a/tests/test_p12n.py
+++ b/tests/test_p12n.py
@@ -48,15 +48,15 @@ class TestSearchpluginAnalysis(unittest.TestCase):
     def testListEnglishSearchplugins(self):
         search_path = os.path.join(self.files_path, 'en-US', 'searchplugins')
 
-        self.p12n.extract_splist_enUS('', search_path, 'browser', 'aurora')
-        self.assertEqual(len(self.p12n.enUS_searchplugins['browser']['aurora']), 2)
-        self.assertIn('google', self.p12n.enUS_searchplugins['browser']['aurora'])
-        self.assertIn('twitter', self.p12n.enUS_searchplugins['browser']['aurora'])
+        self.p12n.extract_shared_splist('', search_path, 'browser', 'aurora')
+        self.assertEqual(len(self.p12n.shared_searchplugins['browser']['aurora']), 2)
+        self.assertIn('google', self.p12n.shared_searchplugins['browser']['aurora'])
+        self.assertIn('twitter', self.p12n.shared_searchplugins['browser']['aurora'])
 
 
     def testExtractInfoSearchpluginEnglish(self):
         search_path = os.path.join(self.files_path, 'en-US', 'searchplugins')
-        self.p12n.enUS_searchplugins = {
+        self.p12n.shared_searchplugins = {
             'browser': {
                 'aurora': ['google', 'twitter']
             }
@@ -87,7 +87,7 @@ class TestSearchpluginAnalysis(unittest.TestCase):
     def testExtractInfoSearchpluginAA(self):
         # Read en-US searchplugins
         search_path = os.path.join(self.files_path, 'en-US', 'searchplugins')
-        self.p12n.enUS_searchplugins = {
+        self.p12n.shared_searchplugins = {
             'browser': {
                 'aurora': ['google', 'twitter']
             }
@@ -144,16 +144,16 @@ class TestSearchpluginAnalysis(unittest.TestCase):
         search_path = os.path.join(self.files_path, 'en-US', 'searchplugins')
         centralized_source = os.path.join(self.files_path, 'list.json')
 
-        self.p12n.extract_splist_enUS(centralized_source, search_path, 'browser', 'aurora')
-        self.assertEqual(len(self.p12n.enUS_searchplugins['browser']['aurora']), 2)
-        self.assertIn('google', self.p12n.enUS_searchplugins['browser']['aurora'])
-        self.assertIn('twitter', self.p12n.enUS_searchplugins['browser']['aurora'])
+        self.p12n.extract_shared_splist(centralized_source, search_path, 'browser', 'aurora')
+        self.assertEqual(len(self.p12n.shared_searchplugins['browser']['aurora']), 2)
+        self.assertIn('google', self.p12n.shared_searchplugins['browser']['aurora'])
+        self.assertIn('twitter', self.p12n.shared_searchplugins['browser']['aurora'])
 
 
     def testCentralizedExtractInfoSearchpluginEnglish(self):
         search_path = os.path.join(self.files_path, 'en-US', 'searchplugins')
         centralized_source = os.path.join(self.files_path, 'list.json')
-        self.p12n.enUS_searchplugins = {
+        self.p12n.shared_searchplugins = {
             'browser': {
                 'aurora': ['google', 'twitter']
             }
@@ -185,7 +185,7 @@ class TestSearchpluginAnalysis(unittest.TestCase):
         # Read en-US searchplugins
         search_path = os.path.join(self.files_path, 'en-US', 'searchplugins')
         centralized_source = os.path.join(self.files_path, 'list.json')
-        self.p12n.enUS_searchplugins = {
+        self.p12n.shared_searchplugins = {
             'browser': {
                 'aurora': ['google', 'twitter']
             }
@@ -241,7 +241,7 @@ class TestSearchpluginAnalysis(unittest.TestCase):
     def testExtractP12nInfo(self):
         # Read searchplugins for locale 'bb'
         search_path = os.path.join(self.files_path, 'bb', 'searchplugins')
-        self.p12n.enUS_searchplugins = {
+        self.p12n.shared_searchplugins = {
             'browser': {
                 'aurora': []
             }
@@ -311,7 +311,7 @@ class TestSearchpluginAnalysis(unittest.TestCase):
 
     def testOutputData(self):
         search_path = os.path.join(self.files_path, 'bb', 'searchplugins')
-        self.p12n.enUS_searchplugins = {
+        self.p12n.shared_searchplugins = {
             'browser': {
                 'aurora': []
             }

--- a/tests/test_p12n.py
+++ b/tests/test_p12n.py
@@ -93,6 +93,8 @@ class TestSearchpluginAnalysis(unittest.TestCase):
             }
         }
         self.p12n.extract_searchplugins_product(
+            '', search_path, 'browser', 'shared', 'aurora')
+        self.p12n.extract_searchplugins_product(
             '', search_path, 'browser', 'en-US', 'aurora')
 
         # Read searchplugins for locale 'aa'
@@ -190,6 +192,8 @@ class TestSearchpluginAnalysis(unittest.TestCase):
                 'aurora': ['google', 'twitter']
             }
         }
+        self.p12n.extract_searchplugins_product(
+            centralized_source, search_path, 'browser', 'shared', 'aurora')
         self.p12n.extract_searchplugins_product(
             centralized_source, search_path, 'browser', 'en-US', 'aurora')
 


### PR DESCRIPTION
Currently en-US lists all searchplugins available in en-US instead of the ones actually available for en-US.

This extracts all searchplugin info from en-US into a pseudo locale ‘shared’, and lists in ‘en-US’ only searchplugins actually shipping.